### PR TITLE
Fix typo in prefix

### DIFF
--- a/src/logic/utils.ts
+++ b/src/logic/utils.ts
@@ -165,7 +165,7 @@ async function createTask(taskTitle: string, url: string): Promise<ITask> {
 
 async function registerDefaultTaskList(url: string): Promise<void> {
   const query = `
-    PREFIX todo: <http://example.org/todolifilest/>
+    PREFIX todo: <http://example.org/todolist/>
 
     INSERT DATA {
       <#default> a todo:TaskList ;


### PR DESCRIPTION
There was a typo in the prefixes, probably caused by a misclick, that was causing the default task list to have the wrong class.